### PR TITLE
to avoid interrupt by truncated image files

### DIFF
--- a/dedup/__main__.py
+++ b/dedup/__main__.py
@@ -8,7 +8,8 @@ from pathos.multiprocessing import Pool
 import json
 import shutil
 import imghdr
-from PIL import Image
+from PIL import Image,ImageFile
+ImageFile.LOAD_TRUNCATED_IMAGES = True
 
 __author__ = "Nii Mante"
 __license__ = "MIT"


### PR DESCRIPTION
truncated image will result in error such as:

================================
Running near deduplication algorithm on images in folder test_images
Found 4511 images in directory: from directory: images
Traceback (most recent call last):
  File "__main__.py", line 366, in <module>
    main()
  File "__main__.py", line 37, in main
    unique_images_count, duplicate_images_count = generate_output(args)
  File "__main__.py", line 339, in generate_output
    near_duplicate_objects = [p.get() for p in results]
  File "/usr/local/lib/python2.7/dist-packages/multiprocess-0.70.6.1-py2.7-linux-x86_64.egg/multiprocess/pool.py", line 572, in get
    raise self._value
IOError: image file is truncated (24 bytes not processed)